### PR TITLE
Restored vanilla default

### DIFF
--- a/common/buildings/te_inv_default.txt
+++ b/common/buildings/te_inv_default.txt
@@ -720,8 +720,7 @@ basic_settlement_infratructure_building = { #Farming Settlement
 	chance = {
 		modifier = {
 			has_food_trade_good_trigger = yes
-			add = 25
-			add = 30
+			add = 15
 		}
 		modifier = {
 			root.state = {


### PR DESCRIPTION
*Invictus v1.4 increased chance for AI to build farming settlements, which caused an issue with the AI spamming farms that they are trying to fix in v1.4c
      -restored default modifier of 15